### PR TITLE
Use correct syntax for engines.node field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "npx eslint test/ index.js"
   },
   "engines": {
-    "node": "^10.17.0"
+    "node": ">= 10.17.0"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
When using a greater node version, the package manager prints the error:
```
error remark-mermaid-dataurl@1.0.0: The engine "node" is incompatible with this module. Expected version "^10.17.0". Got "12.20.0"
```