### PR TITLE
ci: fix Puppeteer CI tests on Ubuntu 24.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,5 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Test
-        run: npm test
+        # Ubuntu 24.04 default AppArmor policy breaks chrome's sandbox
+        run: aa-exec --profile=chrome npm test


### PR DESCRIPTION
Use `aa-exec --profile=chrome` to run our tests and therefore Puppeteer with the `chrome` security profile. This allows chrome to run with the same permissions as it had on Ubuntu 22.04, which is required.

This should fix the failing E2E tests!

See: https://github.com/mermaid-js/mermaid-cli/pull/825